### PR TITLE
中控台archive-list优化

### DIFF
--- a/source/css/_layout/console.styl
+++ b/source/css/_layout/console.styl
@@ -252,13 +252,15 @@
 
   .console-card.history
     .card-archive-list
-      display grid
-      grid-template-columns repeat(4, 1fr)
+      display flex
+      flex-direction row
+      flex-wrap wrap
       gap .5rem
       height auto
+      max-height 164px
 
       li.item
-        width 100%
+        flex 1 1 calc(100% / 4 - 1.5rem)
 
       a
         border-radius 8px


### PR DESCRIPTION
限制中控台archive-list部分的高度，同时回调display显示逻辑，确保文章较少时也能有较好的显示效果